### PR TITLE
Ignore unknown node types

### DIFF
--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -37,6 +37,11 @@ abstract class BlockNode extends Node
         // set content if defined
         if (\array_key_exists('content', $data)) {
             foreach ($data['content'] as $nodeData) {
+                // ignore undefined node types
+                if (!isset(Node::NODE_MAPPING[$nodeData['type']])) {
+                    continue;
+                }
+
                 $class = Node::NODE_MAPPING[$nodeData['type']];
                 $child = $class::load($nodeData, $node);
 

--- a/tests/Node/Block/DocumentTest.php
+++ b/tests/Node/Block/DocumentTest.php
@@ -713,4 +713,18 @@ TXT;
 
         self::assertJsonStringEqualsJsonString($json, $doc->toJson());
     }
+
+    public function testLoadWithUnknownNodeType(): void
+    {
+        $json = <<<'TXT'
+{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hello"},{"type":"unknown","attrs":{"id":"abc"}},{"type":"text","text":" "},{"type":"text","text":"world"}]}]}
+TXT;
+        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $doc = Document::load($data);
+
+        $expectedOutput = <<<'TXT'
+{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hello"},{"type":"text","text":" "},{"type":"text","text":"world"}]}]}
+TXT;
+        self::assertJsonStringEqualsJsonString($expectedOutput, $doc->toJson());
+    }
 }


### PR DESCRIPTION
We came across a Jira issue description that included a type called mediaInline. It caused the parser to crash:

Undefined array key "mediaInline"
vendor/damienharper/adf-tools/src/Node/BlockNode.php:40 DH\Adf\Node\BlockNode::load

This PR includes a condition that ignores undefined types and allows the loading process to continue.
