### PR TITLE
Allow direct append for nodes for complex composition

### DIFF
--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace DH\Adf\Builder;
 
+use DH\Adf\Node\BlockNode;
 use DH\Adf\Node\Node;
 
 trait BuilderInterface
 {
-    abstract protected function append(Node $node): void;
+    abstract public function append(Node ...$nodes): BlockNode;
 }

--- a/src/Builder/InlineNodeBuilder.php
+++ b/src/Builder/InlineNodeBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DH\Adf\Builder;
 
+use DH\Adf\Node\BlockNode;
 use DH\Adf\Node\Inline\Emoji;
 use DH\Adf\Node\Inline\Hardbreak;
 use DH\Adf\Node\Inline\Mention;
@@ -34,5 +35,5 @@ trait InlineNodeBuilder
         return $this;
     }
 
-    abstract protected function append(Node $node): void;
+    abstract public function append(Node ...$nodes): BlockNode;
 }

--- a/src/Builder/TextBuilder.php
+++ b/src/Builder/TextBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DH\Adf\Builder;
 
+use DH\Adf\Node\BlockNode;
 use DH\Adf\Node\Inline\Text;
 use DH\Adf\Node\Mark\Em;
 use DH\Adf\Node\Mark\Link;
@@ -79,5 +80,5 @@ trait TextBuilder
         return $this;
     }
 
-    abstract protected function append(Node $node): void;
+    abstract public function append(Node ...$nodes): BlockNode;
 }

--- a/src/Node/BlockNode.php
+++ b/src/Node/BlockNode.php
@@ -52,16 +52,29 @@ abstract class BlockNode extends Node
         return $this->content;
     }
 
-    protected function append(Node $node): void
+    public function append(Node ...$nodes): BlockNode
     {
-        foreach ($this->allowedContentTypes as $type) {
-            if ($node instanceof $type) {
+        foreach ($nodes as $node) {
+            if ($this->isAppendAllowed($node)) {
                 $this->content[] = $node;
-
-                return;
+            } else {
+                throw new InvalidArgumentException(
+                    sprintf('Invalid content type "%s" for block node "%s".', $node->getType(), $this->getType())
+                );
             }
         }
 
-        throw new InvalidArgumentException(sprintf('Invalid content type "%s" for block node "%s".', $node->type, $this->type));
+        return $this;
+    }
+
+    protected function isAppendAllowed(Node $node): bool
+    {
+        foreach ($this->allowedContentTypes as $allowedContentType) {
+            if ($node instanceof $allowedContentType) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -141,6 +141,11 @@ abstract class Node implements JsonSerializable
         return $node;
     }
 
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
     protected function attrs(): array
     {
         return [];

--- a/tests/Node/Block/DirectAppendTest.php
+++ b/tests/Node/Block/DirectAppendTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Adf\Tests\Node\Block;
+
+use DH\Adf\Node\Block\Document;
+use DH\Adf\Node\Block\Panel;
+use DH\Adf\Node\Block\Paragraph;
+use DH\Adf\Node\Inline\Text;
+use DH\Adf\Node\Mark\Em;
+use DH\Adf\Node\Mark\Link;
+use DH\Adf\Node\Mark\Strike;
+use DH\Adf\Node\Mark\Strong;
+use DH\Adf\Node\Mark\Subsup;
+use DH\Adf\Node\Mark\TextColor;
+use DH\Adf\Node\Mark\Underline;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @small
+ */
+class DirectAppendTest extends TestCase
+{
+    public function testDocumentWithEmptyParagraph(): void
+    {
+        $document = (new Document())
+            ->append(
+                new Paragraph()
+            )
+        ;
+
+        $doc = json_encode($document);
+
+        self::assertJsonStringEqualsJsonString($doc, json_encode([
+            'version' => 1,
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [],
+                ],
+            ],
+        ]));
+    }
+
+    public function testDocumentWithTextInParagraph(): void
+    {
+        $document = (new Document())
+            ->append(
+                (new Paragraph())
+                    ->append(
+                        new Text('Luke, ', new TextColor('red')),
+                        new Text('may '),
+                        new Text('the ', new Em()),
+                        new Text('force ', new Strong()),
+                        new Text('be '),
+                        new Text('with ', new Underline()),
+                        new Text('you! ', new Strike()),
+                        new Text('Obi-Wan', new Subsup('sub')),
+                        new Text('Kenobi', new Subsup('sup')),
+                        new Text('Star Wars @ Wikipedia', new Link('https://wikipedia.org/wiki/Star_Wars'))
+                    ),
+            )
+        ;
+
+        $doc = json_encode($document);
+
+        self::assertJsonStringEqualsJsonString($doc, json_encode([
+            'version' => 1,
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'Luke, ',
+                            'marks' => [
+                                [
+                                    'type' => 'textColor',
+                                    'attrs' => [
+                                        'color' => 'red',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'may ',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'the ',
+                            'marks' => [
+                                [
+                                    'type' => 'em',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'force ',
+                            'marks' => [
+                                [
+                                    'type' => 'strong',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'be ',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'with ',
+                            'marks' => [
+                                [
+                                    'type' => 'underline',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'you! ',
+                            'marks' => [
+                                [
+                                    'type' => 'strike',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'Obi-Wan',
+                            'marks' => [
+                                [
+                                    'type' => 'subsup',
+                                    'attrs' => [
+                                        'type' => 'sub',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'Kenobi',
+                            'marks' => [
+                                [
+                                    'type' => 'subsup',
+                                    'attrs' => [
+                                        'type' => 'sup',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'Star Wars @ Wikipedia',
+                            'marks' => [
+                                [
+                                    'type' => 'link',
+                                    'attrs' => [
+                                        'href' => 'https://wikipedia.org/wiki/Star_Wars',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    public function testIllegalAppend()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid content type "panel" for block node "paragraph".');
+
+        (new Document())
+            ->append(
+                (new Paragraph())
+                    ->append(new Panel())
+            )
+        ;
+    }
+}


### PR DESCRIPTION
The existing solution with chain methods of document build is well suited for cases when the document structure is predetermined, like so:
```php
$document = (new Document())
    ->bulletlist()
        ->item()
            ->paragraph()
                ->text('item 1')
            ->end()
        ->end()
        ->item()
            ->paragraph()
                ->text('item 2')
            ->end()
        ->end()
    ->end()
;
```
However, if you need to create a document programmatically, when parts of the document can be repeated or generated independently, a problem arises of **how to embed pre-created structures of nodes into the document**. When, for example, some nodes must be included in the document under a certain condition, and otherwise must be omitted. 
The existing model of document creation does not allow this.
I faced this problem personally when creating articles on Confluence, and thought it would be nice to have it in the library itself.

My proposal is to allow two alternative ways of constructing a document, one existing through a chain of calls, and one through a direct append of nodes.
```php
        $document = (new Document())
            ->append(
                (new BulletList())
                    ->append(
                        (new ListItem())
                            ->append(
                                (new Paragraph())
                                    ->append(new Text('item 1'))
                            ),
                        (new ListItem())
                            ->append(
                                (new Paragraph())
                                    ->append(new Text('item 2'))
                            )
                            
                    )
            )
        ;
```
In this case, it will be possible to create and append nodes dynamically.
```php
$paragraph = (new Paragraph())->append(new Text('Line 1'));

if (some condition) {
    $paragraph->append(new Text('(doc)', new Link('https://example.com/doc')));
}

$document = (new Document())->append($paragraph);
```

This will allow to create documents of any complexity and will give developers a powerful tool for working with Atlassian products.

This doesn't require much, just change the visibility scope for method `append` to public. I also added the ability to append multiple nodes at once.