### PR TITLE
Added extension node (used in Confluence documents)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -6,6 +6,7 @@ Methods:
 - `Document::bulletlist()` appends a [bulletList](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/bulletList/) block node
 - `Document::codeblock()` appends a [codeBlock](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/codeBlock/) block node
 - `Document::expand()` appends a [expand]() node
+- `Document::extension()` appends an `extension` node
 - `Document::heading()` appends a [heading](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/heading/) block node
 - `Document::mediaGroup()` appends a [mediaGroup](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/mediaGroup/) block node
 - `Document::mediaSingle()` appends a [mediaSingle](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/mediaSingle/) block node
@@ -120,6 +121,7 @@ Methods:
 ## `DH\Adf\Node\Block\Paragraph` class materializes a [paragraph](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/paragraph/) block node
 Methods:
 - `Paragraph::bulletlist()` appends a [bulletList](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/bulletList/) block node
+- `Document::extension()` appends an `extension` node
 - `Paragraph::heading()` appends a [heading](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/heading/) block node
 - `Paragraph::orderedlist()` appends a [orderedList](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/orderedList/) block node
 - `Paragraph::paragraph()` appends a [paragraph](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/paragraph/) block node

--- a/src/Builder/ExtensionBuilder.php
+++ b/src/Builder/ExtensionBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Adf\Builder;
+
+use DH\Adf\Node\Inline\Extension;
+
+trait ExtensionBuilder
+{
+    public function extension(
+        string $layout,
+        string $extensionType,
+        string $extensionKey,
+        array $parameters,
+        string $localId
+    ): self {
+        $mention = new Extension($layout, $extensionType, $extensionKey, $parameters, $localId);
+        $this->append($mention);
+
+        return $this;
+    }
+}

--- a/src/Exporter/Html/HtmlExporter.php
+++ b/src/Exporter/Html/HtmlExporter.php
@@ -25,6 +25,7 @@ use DH\Adf\Exporter\Html\Child\TableHeaderExporter;
 use DH\Adf\Exporter\Html\Child\TableRowExporter;
 use DH\Adf\Exporter\Html\Inline\DateExporter;
 use DH\Adf\Exporter\Html\Inline\EmojiExporter;
+use DH\Adf\Exporter\Html\Inline\ExtensionExporter;
 use DH\Adf\Exporter\Html\Inline\HardbreakExporter;
 use DH\Adf\Exporter\Html\Inline\InlineCardExporter;
 use DH\Adf\Exporter\Html\Inline\MentionExporter;
@@ -59,6 +60,7 @@ use DH\Adf\Node\Child\TableHeader;
 use DH\Adf\Node\Child\TableRow;
 use DH\Adf\Node\Inline\Date;
 use DH\Adf\Node\Inline\Emoji;
+use DH\Adf\Node\Inline\Extension;
 use DH\Adf\Node\Inline\Hardbreak;
 use DH\Adf\Node\Inline\InlineCard;
 use DH\Adf\Node\Inline\Mention;
@@ -103,6 +105,7 @@ abstract class HtmlExporter implements ExporterInterface
 
         // inline nodes
         Emoji::class => EmojiExporter::class,
+        Extension::class => ExtensionExporter::class,
         Hardbreak::class => HardbreakExporter::class,
         Mention::class => MentionExporter::class,
         Text::class => TextExporter::class,

--- a/src/Exporter/Html/Inline/ExtensionExporter.php
+++ b/src/Exporter/Html/Inline/ExtensionExporter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Adf\Exporter\Html\Inline;
+
+use DH\Adf\Exporter\Html\HtmlExporter;
+use DH\Adf\Node\Inline\Extension;
+
+class ExtensionExporter extends HtmlExporter
+{
+    public function export(): string
+    {
+        \assert($this->node instanceof Extension);
+
+        return '<div class="adf-extension">The contents of the extension cannot be exported.</div>';
+    }
+}

--- a/src/Node/Block/Document.php
+++ b/src/Node/Block/Document.php
@@ -8,6 +8,7 @@ use DH\Adf\Builder\BlockquoteBuilder;
 use DH\Adf\Builder\BulletListBuilder;
 use DH\Adf\Builder\CodeblockBuilder;
 use DH\Adf\Builder\ExpandBuilder;
+use DH\Adf\Builder\ExtensionBuilder;
 use DH\Adf\Builder\HeadingBuilder;
 use DH\Adf\Builder\MediaGroupBuilder;
 use DH\Adf\Builder\MediaSingleBuilder;
@@ -17,6 +18,7 @@ use DH\Adf\Builder\ParagraphBuilder;
 use DH\Adf\Builder\RuleBuilder;
 use DH\Adf\Builder\TableBuilder;
 use DH\Adf\Node\BlockNode;
+use DH\Adf\Node\Inline\Extension;
 use JsonSerializable;
 
 /**
@@ -27,6 +29,7 @@ class Document extends BlockNode implements JsonSerializable
     use BlockquoteBuilder;
     use BulletListBuilder;
     use CodeblockBuilder;
+    use ExtensionBuilder;
     use HeadingBuilder;
     use MediaGroupBuilder;
     use MediaSingleBuilder;
@@ -42,6 +45,7 @@ class Document extends BlockNode implements JsonSerializable
         Blockquote::class,
         BulletList::class,
         CodeBlock::class,
+        Extension::class,
         Heading::class,
         MediaGroup::class,
         MediaSingle::class,

--- a/src/Node/Block/Paragraph.php
+++ b/src/Node/Block/Paragraph.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DH\Adf\Node\Block;
 
+use DH\Adf\Builder\ExtensionBuilder;
 use DH\Adf\Builder\InlineNodeBuilder;
 use DH\Adf\Builder\TextBuilder;
 use DH\Adf\Node\BlockNode;
@@ -16,6 +17,7 @@ use JsonSerializable;
  */
 class Paragraph extends BlockNode implements JsonSerializable
 {
+    use ExtensionBuilder;
     use InlineNodeBuilder;
     use TextBuilder;
 

--- a/src/Node/Inline/Extension.php
+++ b/src/Node/Inline/Extension.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Adf\Node\Inline;
+
+use DH\Adf\Node\InlineNode;
+
+class Extension extends InlineNode
+{
+    protected string $type = 'extension';
+    private string $layout;
+    private string $extensionType;
+    private string $extensionKey;
+    private array $parameters;
+    private string $localId;
+
+    public function __construct(
+        string $layout,
+        string $extensionType,
+        string $extensionKey,
+        array $parameters,
+        string $localId
+    ) {
+        $this->layout = $layout;
+        $this->extensionType = $extensionType;
+        $this->extensionKey = $extensionKey;
+        $this->parameters = $parameters;
+        $this->localId = $localId;
+    }
+
+    protected function attrs(): array
+    {
+        $attrs = parent::attrs();
+        $attrs['layout'] = $this->layout;
+        $attrs['extensionType'] = $this->extensionType;
+        $attrs['extensionKey'] = $this->extensionKey;
+        if ($this->parameters) {
+            $attrs['parameters'] = $this->parameters;
+        }
+        $attrs['localId'] = $this->localId;
+
+        return $attrs;
+    }
+}

--- a/tests/Exporter/Html/Block/DocumentExporterTest.php
+++ b/tests/Exporter/Html/Block/DocumentExporterTest.php
@@ -253,6 +253,22 @@ final class DocumentExporterTest extends TestCase
         self::assertSame('<div class="adf-container"><table class="adf-table-default"><tbody><tr><th><p>header 1</p></th><th><p>header 2</p></th></tr><tr><td><p>cell 1</p></td><td><p>cell 2</p></td></tr></tbody></table></div>', $exporter->export());
     }
 
+    public function testDocumentWithExtension()
+    {
+        $document = (new Document())
+            ->extension('default',
+                'com.atlassian.confluence.macro.core',
+                'toc',
+                [],
+                '123cad9c-95d8-49df-8b99-00886ba0af5d',
+            )
+        ;
+
+        $exporter = new DocumentExporter($document);
+
+        self::assertSame('<div class="adf-container"><div class="adf-extension">The contents of the extension cannot be exported.</div></div>', $exporter->export());
+    }
+
     public function testLoad(): void
     {
         $json = <<<'TXT'

--- a/tests/Node/Inline/ExtensionTest.php
+++ b/tests/Node/Inline/ExtensionTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DH\Adf\Tests\Node\Inline;
+
+use DH\Adf\Node\Block\Document;
+use DH\Adf\Node\Inline\Extension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @small
+ */
+final class ExtensionTest extends TestCase
+{
+    public function testExtension(): void
+    {
+        $extension = new Extension(
+            'default',
+            'com.atlassian.confluence.macro.core',
+            'toc',
+            [
+                'macroParams' => [
+                    'minLevel' => [
+                        'value' => '1',
+                    ],
+                    'maxLevel' => [
+                        'value' => '3',
+                    ],
+                    'outline' => [
+                        'value' => 'false',
+                    ],
+                    'type' => [
+                        'value' => 'list',
+                    ],
+                    'printable' => [
+                        'value' => 'false',
+                    ],
+                ],
+            ],
+            '123cad9c-95d8-49df-8b99-00886ba0af5d',
+        );
+        $doc = $extension->toJson();
+
+        self::assertJsonStringEqualsJsonString($doc, json_encode([
+            'type' => 'extension',
+            'attrs' => [
+                "extensionKey" => "toc",
+                "extensionType" => "com.atlassian.confluence.macro.core",
+                "layout" => "default",
+                "localId" => "123cad9c-95d8-49df-8b99-00886ba0af5d",
+                "parameters" => [
+                    "macroParams" => [
+                        "maxLevel" => [
+                            "value" => "3"
+                        ],
+                        "minLevel" => [
+                            "value" => "1"
+                        ],
+                        "outline" => [
+                            "value" => "false"
+                        ],
+                        "printable" => [
+                            "value" => "false"
+                        ],
+                        "type" => [
+                            "value" => "list"
+                        ]
+                    ]
+                ],
+            ],
+        ]));
+    }
+
+    public function testExtensionToDocument(): void
+    {
+        $doc = (new Document())
+            ->extension(
+                'default',
+                'com.atlassian.confluence.macro.core',
+                'toc',
+                [],
+                '123cad9c-95d8-49df-8b99-00886ba0af5d',
+            )
+            ->toJson();
+
+        self::assertJsonStringEqualsJsonString($doc, json_encode([
+            'version' => 1,
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'extension',
+                    'attrs' => [
+                        "extensionKey" => "toc",
+                        "extensionType" => "com.atlassian.confluence.macro.core",
+                        "layout" => "default",
+                        "localId" => "123cad9c-95d8-49df-8b99-00886ba0af5d"
+                    ],
+                ],
+            ],
+        ]));
+    }
+}


### PR DESCRIPTION
Although element `Extension` is not described in [Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/), in practice it is used in documents for the Confluence.

One of the most famous extensions is, for example, the **Table of Contents**.

For the library to fully work with confluence documents, I propose to add this node.
Thanks