### PR TITLE
fixes error when width is not an integer

### DIFF
--- a/src/Node/Block/MediaSingle.php
+++ b/src/Node/Block/MediaSingle.php
@@ -57,7 +57,11 @@ class MediaSingle extends BlockNode implements JsonSerializable
         self::checkNodeData(static::class, $data, ['attrs']);
         self::checkRequiredKeys(['layout'], $data['attrs']);
 
-        $node = new self($data['attrs']['layout'], $data['attrs']['width'] ?? null, $parent);
+        $node = new self(
+            $data['attrs']['layout'],
+            isset($data['attrs']['width']) ? (int) $data['attrs']['width'] : null,
+            $parent
+        );
 
         // set content if defined
         if (\array_key_exists('content', $data)) {

--- a/tests/Node/Block/MediaSingleTest.php
+++ b/tests/Node/Block/MediaSingleTest.php
@@ -48,4 +48,19 @@ final class MediaSingleTest extends TestCase
             ],
         ]));
     }
+
+    public function testWidthWithFloatValue(): void
+    {
+        $json = [
+            'type' => 'mediaSingle',
+            'content' => [],
+            'attrs' => [
+                'layout' => 'wrap-left',
+                'width' => 80.5,
+            ],
+        ];
+
+        $doc = MediaSingle::load($json);
+        $this->assertInstanceOf(MediaSingle::class, $doc);
+    }
 }


### PR DESCRIPTION
Hi,

I have the following error in production:

```
TypeError
DH\Adf\Node\Block\MediaSingle::__construct(): Argument #2 ($width) must be of type ?int, float given, called in /workspace/vendor/damienharper/adf-tools/src/Node/Block/MediaSingle.php on line 60
```

This PR fixes the issue