### PR TITLE
Refactor media dimensions to use float type for width and height

### DIFF
--- a/src/Builder/MediaBuilder.php
+++ b/src/Builder/MediaBuilder.php
@@ -10,7 +10,7 @@ trait MediaBuilder
 {
     use BuilderInterface;
 
-    public function media(string $id, string $mediaType, string $collection, ?int $width = null, ?int $height = null, ?string $occurrenceKey = null): Media
+    public function media(string $id, string $mediaType, string $collection, ?float $width = null, ?float $height = null, ?string $occurrenceKey = null): Media
     {
         $block = new Media($id, $mediaType, $collection, $width, $height, $occurrenceKey, $this);
         $this->append($block);

--- a/src/Builder/MediaSingleBuilder.php
+++ b/src/Builder/MediaSingleBuilder.php
@@ -10,7 +10,7 @@ trait MediaSingleBuilder
 {
     use BuilderInterface;
 
-    public function mediaSingle(string $layout, ?int $width = null): MediaSingle
+    public function mediaSingle(string $layout, ?float $width = null): MediaSingle
     {
         $block = new MediaSingle($layout, $width, $this);
         $this->append($block);

--- a/src/Node/Block/MediaSingle.php
+++ b/src/Node/Block/MediaSingle.php
@@ -31,9 +31,9 @@ class MediaSingle extends BlockNode implements JsonSerializable
         Media::class,
     ];
     private string $layout;
-    private ?int $width;
+    private ?float $width;
 
-    public function __construct(string $layout, ?int $width = null, ?BlockNode $parent = null)
+    public function __construct(string $layout, ?float $width = null, ?BlockNode $parent = null)
     {
         if (!\in_array($layout, [
             self::LAYOUT_WRAP_LEFT,
@@ -49,6 +49,9 @@ class MediaSingle extends BlockNode implements JsonSerializable
 
         parent::__construct($parent);
         $this->layout = $layout;
+
+        if (is_float($width))
+            $width = round($width, 2);
         $this->width = $width;
     }
 
@@ -77,7 +80,7 @@ class MediaSingle extends BlockNode implements JsonSerializable
         return $this->layout;
     }
 
-    public function getWidth(): ?int
+    public function getWidth(): ?float
     {
         return $this->width;
     }

--- a/src/Node/Child/Media.php
+++ b/src/Node/Child/Media.php
@@ -21,10 +21,10 @@ class Media extends Node
     private string $mediaType;
     private string $collection;
     private ?string $occurrenceKey;
-    private ?int $width;
-    private ?int $height;
+    private ?float $width;
+    private ?float $height;
 
-    public function __construct(string $id, string $mediaType, string $collection, ?int $width = null, ?int $height = null, ?string $occurrenceKey = null, ?BlockNode $parent = null)
+    public function __construct(string $id, string $mediaType, string $collection, ?float $width = null, ?float $height = null, ?string $occurrenceKey = null, ?BlockNode $parent = null)
     {
         if (!\in_array($mediaType, [self::TYPE_FILE, self::TYPE_LINK], true)) {
             throw new InvalidArgumentException('Invalid media type');
@@ -35,7 +35,13 @@ class Media extends Node
         $this->mediaType = $mediaType;
         $this->collection = $collection;
         $this->occurrenceKey = $occurrenceKey;
+
+        if (is_float($width))
+            $width = round($width, 2);
         $this->width = $width;
+
+        if (is_float($height))
+            $height = round($height, 2);
         $this->height = $height;
     }
 
@@ -75,12 +81,12 @@ class Media extends Node
         return $this->occurrenceKey;
     }
 
-    public function getWidth(): ?int
+    public function getWidth(): ?float
     {
         return $this->width;
     }
 
-    public function getHeight(): ?int
+    public function getHeight(): ?float
     {
         return $this->height;
     }

--- a/tests/Exporter/Html/Block/DocumentExporterTest.php
+++ b/tests/Exporter/Html/Block/DocumentExporterTest.php
@@ -194,28 +194,28 @@ final class DocumentExporterTest extends TestCase
     {
         $document = (new Document())
             ->mediaSingle(MediaSingle::LAYOUT_WIDE)
-            ->media('6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5', Media::TYPE_FILE, 'my project files', 100, 200)
+            ->media('6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5', Media::TYPE_FILE, 'my project files', 110.7, 200)
             ->end()
             ->end()
         ;
         $exporter = new DocumentExporter($document);
 
-        self::assertSame('<div class="adf-container"><div class="adf-mediasingle"><div class="adf-media"><!--{"type":"media","attrs":{"id":"6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5","type":"file","collection":"my project files","width":100,"height":200}}--><p>Atlassian Media API is not publicly available at the moment.</p></div></div></div>', $exporter->export());
+        self::assertSame('<div class="adf-container"><div class="adf-mediasingle"><div class="adf-media"><!--{"type":"media","attrs":{"id":"6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5","type":"file","collection":"my project files","width":110.7,"height":200}}--><p>Atlassian Media API is not publicly available at the moment.</p></div></div></div>', $exporter->export());
     }
 
     public function testDocumentWithMediaGroup(): void
     {
         $document = (new Document())
             ->mediaGroup()
-            ->media('6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5', Media::TYPE_FILE, 'my project files', 100, 200)
+            ->media('6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5', Media::TYPE_FILE, 'my project files', 100.335, 200)
             ->end()
-            ->media('7a7c7f2c-dd7a-499c-bceb-6f32bfbf30c7', Media::TYPE_FILE, 'my project files', 100, 200)
+            ->media('7a7c7f2c-dd7a-499c-bceb-6f32bfbf30c7', Media::TYPE_FILE, 'my project files', 100, 220.5)
             ->end()
             ->end()
         ;
         $exporter = new DocumentExporter($document);
 
-        self::assertSame('<div class="adf-container"><div class="adf-mediagroup"><div class="adf-media"><!--{"type":"media","attrs":{"id":"6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5","type":"file","collection":"my project files","width":100,"height":200}}--><p>Atlassian Media API is not publicly available at the moment.</p></div><div class="adf-media"><!--{"type":"media","attrs":{"id":"7a7c7f2c-dd7a-499c-bceb-6f32bfbf30c7","type":"file","collection":"my project files","width":100,"height":200}}--><p>Atlassian Media API is not publicly available at the moment.</p></div></div></div>', $exporter->export());
+        self::assertSame('<div class="adf-container"><div class="adf-mediagroup"><div class="adf-media"><!--{"type":"media","attrs":{"id":"6e7c7f2c-dd7a-499c-bceb-6f32bfbf30b5","type":"file","collection":"my project files","width":100.34,"height":200}}--><p>Atlassian Media API is not publicly available at the moment.</p></div><div class="adf-media"><!--{"type":"media","attrs":{"id":"7a7c7f2c-dd7a-499c-bceb-6f32bfbf30c7","type":"file","collection":"my project files","width":100,"height":220.5}}--><p>Atlassian Media API is not publicly available at the moment.</p></div></div></div>', $exporter->export());
     }
 
     public function testDocumentWithTable(): void


### PR DESCRIPTION
Like #19 I've had the issue of an Rest API response not being able to be parsed due to this.
This changes the type of all media width & height variables to float, closes #18